### PR TITLE
Fix wrong hash for the cask wljs-notebook

### DIFF
--- a/Casks/w/wljs-notebook.rb
+++ b/Casks/w/wljs-notebook.rb
@@ -2,8 +2,8 @@ cask "wljs-notebook" do
   arch arm: "-arm64"
 
   version "2.5.0"
-  sha256 arm:   "41b191f3f7c2db1fa9612f74df3b2e6b6d5f67f2c3e0f381b0c2880b640d9c32",
-         intel: "181e28d2a6c0604c009b5c802cb2ce1161c0d79c3666151b9fb37ffc6dc24fb2"
+  sha256 arm:   "5375ac1a51993c205f153a6db71fea501636e062273980a699baf103ec9f6335",
+         intel: "bc4d5fc284ce805b36043f2772274075cc48de75d1a5cfdc7d64b225d98bd355"
 
   url "https://github.com/JerryI/wolfram-js-frontend/releases/download/#{version}/WLJS.Notebook-#{version}#{arch}.dmg"
   name "WLJS Notebook"


### PR DESCRIPTION
The wrong hash is fixed from the current downloadable files.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---
